### PR TITLE
Fix SVG document unit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ AC_PROG_CC
 AC_C_CONST
 
 # Use pkg-config to check for the existence of the cairo libraries
-PKG_CHECK_MODULES(CAIRO,cairo >= 1.2.6)
+PKG_CHECK_MODULES(CAIRO,cairo >= 1.16)
 # Use pkg-config to check for the existence of the poppler-glib libraries
 PKG_CHECK_MODULES(POPPLERGLIB,poppler-glib >= 0.5.4)
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 AC_PREREQ(2.60)
 AC_INIT(pdf2svg, 0.2.1, David Barton <davebarton@cityinthesky.co.uk>)
 AC_CONFIG_SRCDIR([pdf2svg.c])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 # Checks for programs.
 AC_PROG_CC

--- a/pdf2svg.c
+++ b/pdf2svg.c
@@ -64,6 +64,7 @@ int convertPage(PopplerPage *page, const char* svgFilename)
 
 	// Open the SVG file
 	surface = cairo_svg_surface_create(svgFilename, width, height);
+	cairo_svg_surface_set_document_unit(surface, CAIRO_SVG_UNIT_PT);
 	drawcontext = cairo_create(surface);
 
 	// Render the PDF file into the SVG file


### PR DESCRIPTION
Using cairo 1.17.6 and later, pdf2svg outputs SVGs with the wrong width and height.

Starting with cairo 1.17.6, the default SVG units have been changed from pt to user units.
https://gitlab.freedesktop.org/cairo/cairo/-/issues/545

pdf2svg do not set the SVG unit, and the change in cairo's default caused pdfcairo's SVG output to be incorrect.

This pull request makes pdf2svg set the SVG unit to pt.
So, pdf2svg outputs SVGs that have the correct width and height.